### PR TITLE
Make cache immutable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* items in the cache no longer mutable by other post-caching manipulation
+
+### Changed
+* Moved to class syntax and removed prototype-namespacing of catalog methods (breaking, since public methods, but not breaking for usage in koop-core)
+
 ## [1.2.0] - 2022-06-23
 ### Changed
 * Fixed an issue where some geojson properties (like `crs`) were lost in the caching procedure

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,20 +1,20 @@
-const _ = require('lodash')
+const _ = require('lodash');
 
 function asCachableGeojson(geojson) {
-    if(!geojson || Array.isArray(geojson)) {
-      return {
-        type: 'FeatureCollection',
-        features: geojson ?? [],
-        metadata: {}
-      }
-    }
- 
-    geojson.type = geojson.type || 'FeatureCollection'
-    geojson.features = geojson.features || [];
-    geojson.metadata = geojson.metadata || {};
-    return _.cloneDeep(geojson);
+  if (!geojson || Array.isArray(geojson)) {
+    return {
+      type: 'FeatureCollection',
+      features: geojson ?? [],
+      metadata: {},
+    };
   }
 
-  module.exports = {
-    asCachableGeojson
-  }
+  geojson.type = geojson.type || 'FeatureCollection';
+  geojson.features = geojson.features || [];
+  geojson.metadata = geojson.metadata || {};
+  return _.cloneDeep(geojson);
+}
+
+module.exports = {
+  asCachableGeojson,
+};

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 function asCachableGeojson(geojson) {
     if(!geojson || Array.isArray(geojson)) {
       return {
@@ -10,7 +12,7 @@ function asCachableGeojson(geojson) {
     geojson.type = geojson.type || 'FeatureCollection'
     geojson.features = geojson.features || [];
     geojson.metadata = geojson.metadata || {};
-    return geojson;
+    return _.cloneDeep(geojson);
   }
 
   module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,105 +7,148 @@ const Readable = require('stream').Readable
 // Convenience to make callbacks optional in most functions
 function noop() { }
 
-function Cache(options = {}) {
-  this.store = new Map()
-  this.catalog.store = new Map()
-  this.catalog.dataStore = this.store
-}
+class Cache extends EventEmitter {
+  static name = 'Memory Cache';
+  static type = 'cache';
+  static version = require('../package.json').version;
 
-Cache.name = 'Memory Cache'
-Cache.type = 'cache'
-Cache.version = require('../package.json').version
+  constructor (options = {}) {
+    super();
+    this.store = new Map();
+    this.catalogStore = new Map();
+  }
 
-Util.inherits(Cache, EventEmitter)
+  insert (key, geojson, options = {}, callback = noop) {
+    if (this.store.has(key)) {
+      return callback(new Error('Cache key is already in use'));
+    }
+    const { features, ...rest } = asCachableGeojson(geojson);
+    this.store.set(key, features);
 
-Cache.prototype.insert = function (key, geojson, options = {}, callback = noop) {
-  if (this.store.has(key)) return callback(new Error('Cache key is already in use'))
-  geojson = asCachableGeojson(geojson);
-  this.store.set(key, geojson)
-  const metadata = geojson.metadata;
-  if (options.ttl) metadata.expires = Date.now() + (options.ttl * 1000)
-  this.catalog.insert(key, geojson.metadata, callback)
-}
+    this.catalogInsert(key, rest, options, callback);
+  }
 
-Cache.prototype.upsert = function (key, geojson, options = {}, callback = noop) {
-  if (this.store.has(key)) {
-    this.update(key, geojson, options, callback)
-  } else {
-    this.insert(key, geojson, options, callback)
+  update (key, geojson, options = {}, callback = noop) {
+    if (!this.store.has(key)) {
+      return callback(new Error('Resource not found'));
+    }
+    const { features, ...rest } = asCachableGeojson(geojson);
+    
+    this.store.set(key, features);
+    
+    const existingCatalogEntry = this.catalogStore.get(key);
+    
+    const catalogEntry = rest || existingCatalogEntry;
+
+    this.catalogUpdate(key, catalogEntry, callback);
+  }
+
+  upsert (key, geojson, options = {}, callback = noop) {
+    if (this.store.has(key)) {
+      this.update(key, geojson, options, callback);
+    } else {
+      this.insert(key, geojson, options, callback);
+    }
+  }
+
+  append (key, geojson, options = {}, callback = noop) {
+    const { features } = asCachableGeojson(geojson);
+    const existingFeatures = this.store.get(key)
+    const appendedFeatureArray = existingFeatures.concat(features);
+    this.store.set(key, appendedFeatureArray);
+    this.catalogUpdate(key, {
+      cache: {
+        updated: Date.now()
+      }
+    });
+    callback()
+  }
+
+  retrieve (key, options, callback = noop) {
+    if (!this.store.has(key)) {
+      return callback(new Error('Resource not found'));
+    }
+    const features = this.store.get(key);
+
+    const geojsonWrapper = this.catalogStore.get(key);
+
+    const geojson = { ...geojsonWrapper, features };
+    
+    callback(null, geojson);
+
+    return geojson
+  }
+
+  createStream (key, options = {}) {
+    const features = this.store.get(key);
+    return Readable.from(features);
+  }
+
+  delete (key, callback = noop) {
+    if (!this.store.has(key)) {
+      return callback(new Error('Resource not found'));
+    }
+    this.store.delete(key)
+    const catalogEntry = this.catalogStore.get(key)
+    this.catalogStore.set(key, {
+      ...catalogEntry,
+      _cache: {
+        status: 'deleted',
+        updated: Date.now()
+      }
+    })
+    callback()
+  }
+
+  catalogInsert (key, catalogEntry, options, callback = noop) {
+    if (this.catalogStore.has(key)) {
+      return callback(new Error('Catalog key is already in use'));
+    }
+    const clonedEntry = _.cloneDeep(catalogEntry);
+
+    _.set(clonedEntry, '_cache.updated', Date.now());
+
+    if (options.ttl) {
+      _.set(clonedEntry, '_cache.expires', Date.now() + (options.ttl * 1000));
+    }
+
+    this.catalogStore.set(key, clonedEntry)
+
+    callback()
+  }
+  
+  catalogUpdate = function (key, update, options, callback = noop) {
+    if (!this.catalogStore.has(key)) {
+      return callback(new Error('Resource not found'));
+    }
+    const existingCatalogEntry = this.catalogStore.get(key)
+    const catalogEntry = {
+      ...existingCatalogEntry,
+      ..._.cloneDeep(update),
+    }
+    catalogEntry._cache.updated = Date.now()
+    this.catalogStore.set(key, catalogEntry)
+    callback()
+  }
+  
+  catalogRetrieve (key, callback = noop) {
+    if (!this.catalogStore.has(key)) {
+      return callback(new Error('Resource not found'))
+    }
+    const catalogEntry = this.catalogStore.get(key)
+    callback(null, catalogEntry)
+    return catalogEntry
+  }
+  
+  catalogDelete (key, callback = noop) {
+    if (this.store.has(key)) {
+      return callback(new Error('Cannot delete catalog entry while data is still in cache'));
+    }
+    this.catalogStore.delete(key)
+    callback()
   }
 }
 
-Cache.prototype.update = function (key, geojson, options = {}, callback = noop) {
-  if (!this.store.has(key)) return callback(new Error('Resource not found'))
-  geojson = asCachableGeojson(geojson);
-  this.store.set(key, geojson)
-  const existingMetadata = this.catalog.store.get(key)
-  const metadata = geojson.metadata || existingMetadata
-  if (options.ttl) metadata.expires = Date.now() + (options.ttl * 1000)
-  this.catalog.update(key, metadata, callback)
-}
 
-Cache.prototype.append = function (key, geojson, options = {}, callback = noop) {
-  geojson = asCachableGeojson(geojson);
-  const existing = this.store.get(key)
-  existing.features = existing.features.concat(geojson.features)
-  this.catalog.update(key, { updated: Date.now() })
-  callback()
-}
-
-Cache.prototype.retrieve = function (key, options, callback = noop) {
-  if (!this.store.has(key)) return callback(new Error('Resource not found'))
-  const geojson = this.store.get(key)
-  geojson.metadata = this.catalog.store.get(key)
-  callback(null, geojson)
-  return geojson
-}
-
-Cache.prototype.createStream = function (key, options = {}) {
-  const geojson = this.store.get(key)
-  return Readable.from(geojson.features)
-}
-
-Cache.prototype.delete = function (key, callback = noop) {
-  if (!this.store.has(key)) return callback(new Error('Resource not found'))
-  this.store.delete(key)
-  const metadata = this.catalog.store.get(key)
-  metadata.status = 'deleted'
-  metadata.updated = Date.now()
-  this.catalog.store.set(key, metadata)
-  callback()
-}
-
-Cache.prototype.catalog = {}
-
-Cache.prototype.catalog.insert = function (key, metadata, callback = noop) {
-  if (this.store.has(key)) return callback(new Error('Catalog key is already in use'))
-  metadata.updated = Date.now()
-  this.store.set(key, metadata)
-  callback()
-}
-
-Cache.prototype.catalog.update = function (key, update, callback = noop) {
-  if (!this.store.has(key)) return callback(new Error('Resource not found'))
-  const existing = this.store.get(key)
-  const metadata = _.merge(existing, update)
-  metadata.updated = Date.now()
-  this.store.set(key, metadata)
-  callback()
-}
-
-Cache.prototype.catalog.retrieve = function (key, callback = noop) {
-  if (!this.store.has(key)) return callback(new Error('Resource not found'))
-  const metadata = this.store.get(key)
-  callback(null, metadata)
-  return metadata
-}
-
-Cache.prototype.catalog.delete = function (key, callback = noop) {
-  if (this.dataStore.has(key)) return callback(new Error('Cannot delete catalog entry while data is still in cache'))
-  this.store.delete(key)
-  callback()
-}
 
 module.exports = Cache

--- a/test/index.js
+++ b/test/index.js
@@ -1,172 +1,263 @@
-const test = require('tape')
-const Cache = require('../src')
-const cache = new Cache()
-const _ = require('lodash')
-const { asCachableGeojson } = require('../src/helper')
+const test = require("tape");
+const Cache = require("../src");
+const cache = new Cache();
+const _ = require("lodash");
+const { asCachableGeojson } = require("../src/helper");
 
 function getFeatures() {
   return {
-    type: 'FeatureCollection',
+    type: "FeatureCollection",
     crs: {
-      type: 'name',
+      type: "name",
       properties: {
-        type: 'EPSG:4326'
-      }
+        type: "EPSG:4326",
+      },
     },
     metadata: {
-      name: 'Test',
-      description: 'Test'
+      name: "Test",
+      description: "Test",
     },
     features: [
       {
-        type: 'Feature',
+        type: "Feature",
         properties: {
-          key: 'value'
+          key: "value",
         },
         geometry: {
-          foo: 'bar'
-        }
-      }
-    ]
-  }
+          foo: "bar",
+        },
+      },
+    ],
+  };
 }
 
-test('Inserting and retreiving from the cache', t => {
+test("Inserting and retreiving from the cache", (t) => {
   const geojson = getFeatures();
-  cache.insert('key', geojson, {ttl: 600})
-  const cached = cache.retrieve('key')
-  t.equal(cached.features[0].properties.key, 'value', 'retrieved features')
-  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved metadata')
-  t.ok(cached.metadata.expires, 'expiration set')
-  t.ok(cached.metadata.updated, 'updated set')
-  t.end()
-})
+  cache.insert("key", geojson, { ttl: 600 });
+  const cached = cache.retrieve("key");
+  t.equal(cached.features[0].properties.key, "value", "retrieved features");
+  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+  t.equal(cached.metadata.name, "Test", "retrieved metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
 
-test('Upserting and streaming from the cache', t => {
+test("Upserting and streaming from the cache", (t) => {
   const geojson = getFeatures();
-  cache.upsert('key', geojson, {ttl: 600})
-  const readstream = cache.createStream('key')
+  cache.upsert("key", geojson, { ttl: 600 });
+  const readstream = cache.createStream("key");
   readstream.on("data", (chunk) => {
-    t.deepEquals(chunk, geojson.features[0])
-    t.end()
-  })
-})
+    t.deepEquals(chunk, geojson.features[0]);
+    t.end();
+  });
+});
 
-test('Inserting and retreiving from the cache using upsert when the cache is empty', t => {
+test("Inserting and retreiving from the cache using upsert when the cache is empty", (t) => {
   const geojson = getFeatures();
-  cache.upsert('keyupsert', geojson, {ttl: 600})
-  const cached = cache.retrieve('keyupsert')
-  t.equal(cached.features[0].properties.key, 'value', 'retrieved features')
-  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved metadata')
-  t.ok(cached.metadata.expires, 'expiration set')
-  t.ok(cached.metadata.updated, 'updated set')
-  t.end()
-})
+  cache.upsert("keyupsert", geojson, { ttl: 600 });
+  const cached = cache.retrieve("keyupsert");
+  t.equal(cached.features[0].properties.key, "value", "retrieved features");
+  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+  t.equal(cached.metadata.name, "Test", "retrieved metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
 
-test('Inserting and retreiving from the cache using upsert when the cache is filled', t => {
+test("Inserting and retreiving from the cache using upsert when the cache is filled", (t) => {
   const geojson = getFeatures();
-  cache.insert('keyupsertupdate', geojson, {ttl: 600})
-  const geojson2 = _.cloneDeep(geojson)
-  geojson2.features[0].properties['key'] = 'updated'
-  cache.upsert('keyupsertupdate', geojson2, {ttl: 600})
-  const cached = cache.retrieve('keyupsertupdate')
-  t.equal(cached.features[0].properties.key, 'updated', 'retrieved features')
-  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved metadata')
-  t.ok(cached.metadata.expires, 'expiration set')
-  t.ok(cached.metadata.updated, 'updated set')
-  t.end()
-})
+  cache.insert("keyupsertupdate", geojson, { ttl: 600 });
+  const geojson2 = _.cloneDeep(geojson);
+  geojson2.features[0].properties["key"] = "updated";
+  cache.upsert("keyupsertupdate", geojson2, { ttl: 600 });
+  const cached = cache.retrieve("keyupsertupdate");
+  t.equal(cached.features[0].properties.key, "updated", "retrieved features");
+  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+  t.equal(cached.metadata.name, "Test", "retrieved metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
 
-test('Inserting and retreiving from the cache callback style', t => {
+test("Inserting and retreiving from the cache callback style", (t) => {
   const geojson = getFeatures();
-  cache.insert('keyb', geojson, {ttl: 600}, (err) => {
-    t.error(err, 'no error')
-    const cached = cache.retrieve('keyb')
-  t.equal(cached.features[0].properties.key, 'value', 'retrieved features')
-  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved metadata')
-    t.ok(cached.metadata.expires, 'expiration set')
-    t.ok(cached.metadata.updated, 'updated set')
-    t.end()
-  })
-})
+  cache.insert("keyb", geojson, { ttl: 600 }, (err) => {
+    t.error(err, "no error");
+    const cached = cache.retrieve("keyb");
+    t.equal(cached.features[0].properties.key, "value", "retrieved features");
+    t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+    t.equal(cached.metadata.name, "Test", "retrieved metadata");
+    t.ok(cached._cache.expires, "expiration set");
+    t.ok(cached._cache.updated, "updated set");
+    t.end();
+  });
+});
 
-test('Inserting and appending to the cache', t => {
+test("Inserting and appending to the cache", (t) => {
   const geojson = getFeatures();
-  cache.insert('key2', geojson, {ttl: 600})
-  cache.append('key2', geojson)
-  const cached = cache.retrieve('key2')
-  t.equal(cached.features.length, 2, 'retrieved all features')
-  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved metadata')
-  t.ok(cached.metadata.expires, 'expiration set')
-  t.ok(cached.metadata.updated, 'updated set')
-  t.end()
-})
+  cache.insert("key2", geojson, { ttl: 600 });
+  cache.append("key2", geojson);
+  const cached = cache.retrieve("key2");
+  t.equal(cached.features.length, 2, "retrieved all features");
+  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+  t.equal(cached.metadata.name, "Test", "retrieved metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
 
-test('Updating an existing entry in the cache', t => {
+test("Updating an existing entry in the cache", (t) => {
   const geojson = getFeatures();
-  cache.insert('key3', geojson, {ttl: 600})
-  const geojson2 = _.cloneDeep(geojson)
-  geojson2.features[0].properties.key = 'test2'
-  cache.update('key3', geojson2, {ttl: 1000})
-  const cached = cache.retrieve('key3')
-  t.equal(cached.features[0].properties.key, 'test2', 'retrieved only new features')
-  t.equal(cached.features.length, 1, 'retrieved only new features')
-  t.equal(cached.crs.type, 'name', 'retrieved original coordinate reference system')
-  t.equal(cached.metadata.name, 'Test', 'retrieved original metadata')
-  t.ok(cached.metadata.expires, 'expiration set')
-  t.ok(cached.metadata.updated, 'updated set')
-  t.end()
-})
+  cache.insert("key3", geojson, { ttl: 600 });
+  const geojson2 = _.cloneDeep(geojson);
+  geojson2.features[0].properties.key = "test2";
+  cache.update("key3", geojson2, { ttl: 1000 });
+  const cached = cache.retrieve("key3");
+  t.equal(
+    cached.features[0].properties.key,
+    "test2",
+    "retrieved only new features"
+  );
+  t.equal(cached.features.length, 1, "retrieved only new features");
+  t.equal(
+    cached.crs.type,
+    "name",
+    "retrieved original coordinate reference system"
+  );
+  t.equal(cached.metadata.name, "Test", "retrieved original metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
 
-test('Inserting and deleting from the cache', t => {
+test("Inserting and deleting from the cache", (t) => {
   const geojson = getFeatures();
-  t.plan(2)
-  cache.insert('key4', geojson)
-  cache.delete('key4')
-  cache.retrieve('key4', {}, (err, data) => {
-    t.ok(err, 'Should return an error')
-    t.equal(err.message, 'Resource not found', 'Error should have correct message')
-  })
-})
+  t.plan(2);
+  cache.insert("key4", geojson);
+  cache.delete("key4");
+  cache.retrieve("key4", {}, (err, data) => {
+    t.ok(err, "Should return an error");
+    t.equal(
+      err.message,
+      "Resource not found",
+      "Error should have correct message"
+    );
+  });
+});
 
-test('Trying to call insert when something is already in the cache', t => {
+test("Trying to call insert when something is already in the cache", (t) => {
   const geojson = getFeatures();
-  t.plan(2)
-  cache.insert('key5', geojson)
-  cache.insert('key5', geojson, {}, err => {
-    t.ok(err, 'Should return an error')
-    t.equal(err.message, 'Cache key is already in use', 'Error should have correct message')
-  })
-})
+  t.plan(2);
+  cache.insert("key5", geojson);
+  cache.insert("key5", geojson, {}, (err) => {
+    t.ok(err, "Should return an error");
+    t.equal(
+      err.message,
+      "Cache key is already in use",
+      "Error should have correct message"
+    );
+  });
+});
 
-test('Trying to delete the catalog entry when something is still in the cache', t => {
+test("Trying to delete the catalog entry when something is still in the cache", (t) => {
   const geojson = getFeatures();
-  t.plan(2)
-  cache.insert('key6', geojson)
-  cache.catalog.delete('key6', err => {
-    t.ok(err, 'Should return an error')
-    t.equal(err.message, 'Cannot delete catalog entry while data is still in cache', 'Error should have correct message')
-  })
-})
+  t.plan(2);
+  cache.insert("key6", geojson);
+  cache.catalogDelete("key6", (err) => {
+    t.ok(err, "Should return an error");
+    t.equal(
+      err.message,
+      "Cannot delete catalog entry while data is still in cache",
+      "Error should have correct message"
+    );
+  });
+});
 
-test('Helper prepares geojson for cache', t => {
-  const full = getFeatures()
-  const features = full.features
-  const empty = {}
-  const fullGeojson = asCachableGeojson(full)
-  const featuresAsGeojson = asCachableGeojson(features)
-  const emptyAsGeojson = asCachableGeojson(empty)
-  const nullAsGeojson = asCachableGeojson(null)
-  const undefinedAsGeojson = asCachableGeojson(undefined)
-  t.equal(fullGeojson.features[0].properties.key, 'value', 'Full geojson stays geojson')  
-  t.equal(featuresAsGeojson.features[0].properties.key, 'value', 'Features is converted to geojson') 
-  t.equal(emptyAsGeojson.features.length, 0, 'Empty object becomes geojson')
-  t.equal(nullAsGeojson.features.length, 0, 'Null object becomes geojson')
-  t.equal(undefinedAsGeojson.features.length, 0, 'Undefined object becomes geojson')
-  t.end()
-})
+test("Retrieve catalog entry after its data has been deleted", (t) => {
+  const geojson = getFeatures();
+  t.plan(1);
+  cache.insert("key6", geojson);
+  cache.delete("key6");
+  const catalogEntry = cache.catalogRetrieve("key6");
+  t.deepEquals(_.omit(catalogEntry, '_cache'), {
+    type: "FeatureCollection",
+    crs: { type: "name", properties: { type: "EPSG:4326" } },
+    metadata: { name: "Test", description: "Test" }
+  });
+});
+
+test("Delete the catalog entry after its data has been deleted", (t) => {
+  const geojson = getFeatures();
+  t.plan(2);
+  cache.insert("key6", geojson);
+  cache.delete("key6");
+  cache.catalogDelete("key6");
+  cache.catalogRetrieve("key6", (err) => {
+    t.ok(err, "Should return an error");
+    t.equal(
+      err.message,
+      "Resource not found",
+      "Error should have correct message"
+    );
+  });
+});
+
+test("Helper prepares geojson for cache", (t) => {
+  const full = getFeatures();
+  const features = full.features;
+  const empty = {};
+  const fullGeojson = asCachableGeojson(full);
+  const featuresAsGeojson = asCachableGeojson(features);
+  const emptyAsGeojson = asCachableGeojson(empty);
+  const nullAsGeojson = asCachableGeojson(null);
+  const undefinedAsGeojson = asCachableGeojson(undefined);
+  t.equal(
+    fullGeojson.features[0].properties.key,
+    "value",
+    "Full geojson stays geojson"
+  );
+  t.equal(
+    featuresAsGeojson.features[0].properties.key,
+    "value",
+    "Features is converted to geojson"
+  );
+  t.equal(emptyAsGeojson.features.length, 0, "Empty object becomes geojson");
+  t.equal(nullAsGeojson.features.length, 0, "Null object becomes geojson");
+  t.equal(
+    undefinedAsGeojson.features.length,
+    0,
+    "Undefined object becomes geojson"
+  );
+  t.end();
+});
+
+test("Post-insert edits to geojson should not mutate cache", (t) => {
+  const geojson = getFeatures();
+  cache.insert("key", geojson, { ttl: 600 });
+  geojson.features[0].properties.key = "fooz";
+  const cached = cache.retrieve("key");
+  t.equal(cached.features[0].properties.key, "value", "retrieved features");
+  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
+  t.equal(cached.metadata.name, "Test", "retrieved metadata");
+  t.ok(cached._cache.expires, "expiration set");
+  t.ok(cached._cache.updated, "updated set");
+  t.end();
+});
+
+test("Post-update edits to geojson should not mutate cache", (t) => {
+  const geojson = getFeatures();
+  const geojson2 = _.cloneDeep(geojson);
+  geojson2.features[0].properties.key = "test2";
+
+  cache.insert("key3", geojson, { ttl: 600 });
+  cache.update("key3", geojson2, { ttl: 1000 });
+  geojson.features[0].properties.key = "fooz";
+  const cached = cache.retrieve("key3");
+  t.equal(
+    cached.features[0].properties.key,
+    "test2",
+    "retrieved unmutated feature"
+  );
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,209 +1,209 @@
-const test = require("tape");
-const Cache = require("../src");
+const test = require('tape');
+const Cache = require('../src');
 const cache = new Cache();
-const _ = require("lodash");
-const { asCachableGeojson } = require("../src/helper");
+const _ = require('lodash');
+const { asCachableGeojson } = require('../src/helper');
 
 function getFeatures() {
   return {
-    type: "FeatureCollection",
+    type: 'FeatureCollection',
     crs: {
-      type: "name",
+      type: 'name',
       properties: {
-        type: "EPSG:4326",
+        type: 'EPSG:4326',
       },
     },
     metadata: {
-      name: "Test",
-      description: "Test",
+      name: 'Test',
+      description: 'Test',
     },
     features: [
       {
-        type: "Feature",
+        type: 'Feature',
         properties: {
-          key: "value",
+          key: 'value',
         },
         geometry: {
-          foo: "bar",
+          foo: 'bar',
         },
       },
     ],
   };
 }
 
-test("Inserting and retreiving from the cache", (t) => {
+test('Inserting and retreiving from the cache', (t) => {
   const geojson = getFeatures();
-  cache.insert("key", geojson, { ttl: 600 });
-  const cached = cache.retrieve("key");
-  t.equal(cached.features[0].properties.key, "value", "retrieved features");
-  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-  t.equal(cached.metadata.name, "Test", "retrieved metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  cache.insert('key', geojson, { ttl: 600 });
+  const cached = cache.retrieve('key');
+  t.equal(cached.features[0].properties.key, 'value', 'retrieved features');
+  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+  t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Upserting and streaming from the cache", (t) => {
+test('Upserting and streaming from the cache', (t) => {
   const geojson = getFeatures();
-  cache.upsert("key", geojson, { ttl: 600 });
-  const readstream = cache.createStream("key");
-  readstream.on("data", (chunk) => {
+  cache.upsert('key', geojson, { ttl: 600 });
+  const readstream = cache.createStream('key');
+  readstream.on('data', (chunk) => {
     t.deepEquals(chunk, geojson.features[0]);
     t.end();
   });
 });
 
-test("Inserting and retreiving from the cache using upsert when the cache is empty", (t) => {
+test('Inserting and retreiving from the cache using upsert when the cache is empty', (t) => {
   const geojson = getFeatures();
-  cache.upsert("keyupsert", geojson, { ttl: 600 });
-  const cached = cache.retrieve("keyupsert");
-  t.equal(cached.features[0].properties.key, "value", "retrieved features");
-  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-  t.equal(cached.metadata.name, "Test", "retrieved metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  cache.upsert('keyupsert', geojson, { ttl: 600 });
+  const cached = cache.retrieve('keyupsert');
+  t.equal(cached.features[0].properties.key, 'value', 'retrieved features');
+  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+  t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Inserting and retreiving from the cache using upsert when the cache is filled", (t) => {
+test('Inserting and retreiving from the cache using upsert when the cache is filled', (t) => {
   const geojson = getFeatures();
-  cache.insert("keyupsertupdate", geojson, { ttl: 600 });
+  cache.insert('keyupsertupdate', geojson, { ttl: 600 });
   const geojson2 = _.cloneDeep(geojson);
-  geojson2.features[0].properties["key"] = "updated";
-  cache.upsert("keyupsertupdate", geojson2, { ttl: 600 });
-  const cached = cache.retrieve("keyupsertupdate");
-  t.equal(cached.features[0].properties.key, "updated", "retrieved features");
-  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-  t.equal(cached.metadata.name, "Test", "retrieved metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  geojson2.features[0].properties['key'] = 'updated';
+  cache.upsert('keyupsertupdate', geojson2, { ttl: 600 });
+  const cached = cache.retrieve('keyupsertupdate');
+  t.equal(cached.features[0].properties.key, 'updated', 'retrieved features');
+  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+  t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Inserting and retreiving from the cache callback style", (t) => {
+test('Inserting and retreiving from the cache callback style', (t) => {
   const geojson = getFeatures();
-  cache.insert("keyb", geojson, { ttl: 600 }, (err) => {
-    t.error(err, "no error");
-    const cached = cache.retrieve("keyb");
-    t.equal(cached.features[0].properties.key, "value", "retrieved features");
-    t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-    t.equal(cached.metadata.name, "Test", "retrieved metadata");
-    t.ok(cached._cache.expires, "expiration set");
-    t.ok(cached._cache.updated, "updated set");
+  cache.insert('keyb', geojson, { ttl: 600 }, (err) => {
+    t.error(err, 'no error');
+    const cached = cache.retrieve('keyb');
+    t.equal(cached.features[0].properties.key, 'value', 'retrieved features');
+    t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+    t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+    t.ok(cached._cache.expires, 'expiration set');
+    t.ok(cached._cache.updated, 'updated set');
     t.end();
   });
 });
 
-test("Inserting and appending to the cache", (t) => {
+test('Inserting and appending to the cache', (t) => {
   const geojson = getFeatures();
-  cache.insert("key2", geojson, { ttl: 600 });
-  cache.append("key2", geojson);
-  const cached = cache.retrieve("key2");
-  t.equal(cached.features.length, 2, "retrieved all features");
-  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-  t.equal(cached.metadata.name, "Test", "retrieved metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  cache.insert('key2', geojson, { ttl: 600 });
+  cache.append('key2', geojson);
+  const cached = cache.retrieve('key2');
+  t.equal(cached.features.length, 2, 'retrieved all features');
+  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+  t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Updating an existing entry in the cache", (t) => {
+test('Updating an existing entry in the cache', (t) => {
   const geojson = getFeatures();
-  cache.insert("key3", geojson, { ttl: 600 });
+  cache.insert('key3', geojson, { ttl: 600 });
   const geojson2 = _.cloneDeep(geojson);
-  geojson2.features[0].properties.key = "test2";
-  cache.update("key3", geojson2, { ttl: 1000 });
-  const cached = cache.retrieve("key3");
+  geojson2.features[0].properties.key = 'test2';
+  cache.update('key3', geojson2, { ttl: 1000 });
+  const cached = cache.retrieve('key3');
   t.equal(
     cached.features[0].properties.key,
-    "test2",
-    "retrieved only new features"
+    'test2',
+    'retrieved only new features'
   );
-  t.equal(cached.features.length, 1, "retrieved only new features");
+  t.equal(cached.features.length, 1, 'retrieved only new features');
   t.equal(
     cached.crs.type,
-    "name",
-    "retrieved original coordinate reference system"
+    'name',
+    'retrieved original coordinate reference system'
   );
-  t.equal(cached.metadata.name, "Test", "retrieved original metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  t.equal(cached.metadata.name, 'Test', 'retrieved original metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Inserting and deleting from the cache", (t) => {
+test('Inserting and deleting from the cache', (t) => {
   const geojson = getFeatures();
   t.plan(2);
-  cache.insert("key4", geojson);
-  cache.delete("key4");
-  cache.retrieve("key4", {}, (err, data) => {
-    t.ok(err, "Should return an error");
+  cache.insert('key4', geojson);
+  cache.delete('key4');
+  cache.retrieve('key4', {}, (err, data) => {
+    t.ok(err, 'Should return an error');
     t.equal(
       err.message,
-      "Resource not found",
-      "Error should have correct message"
+      'Resource not found',
+      'Error should have correct message'
     );
   });
 });
 
-test("Trying to call insert when something is already in the cache", (t) => {
+test('Trying to call insert when something is already in the cache', (t) => {
   const geojson = getFeatures();
   t.plan(2);
-  cache.insert("key5", geojson);
-  cache.insert("key5", geojson, {}, (err) => {
-    t.ok(err, "Should return an error");
+  cache.insert('key5', geojson);
+  cache.insert('key5', geojson, {}, (err) => {
+    t.ok(err, 'Should return an error');
     t.equal(
       err.message,
-      "Cache key is already in use",
-      "Error should have correct message"
+      'Cache key is already in use',
+      'Error should have correct message'
     );
   });
 });
 
-test("Trying to delete the catalog entry when something is still in the cache", (t) => {
+test('Trying to delete the catalog entry when something is still in the cache', (t) => {
   const geojson = getFeatures();
   t.plan(2);
-  cache.insert("key6", geojson);
-  cache.catalogDelete("key6", (err) => {
-    t.ok(err, "Should return an error");
+  cache.insert('key6', geojson);
+  cache.catalogDelete('key6', (err) => {
+    t.ok(err, 'Should return an error');
     t.equal(
       err.message,
-      "Cannot delete catalog entry while data is still in cache",
-      "Error should have correct message"
+      'Cannot delete catalog entry while data is still in cache',
+      'Error should have correct message'
     );
   });
 });
 
-test("Retrieve catalog entry after its data has been deleted", (t) => {
+test('Retrieve catalog entry after its data has been deleted', (t) => {
   const geojson = getFeatures();
   t.plan(1);
-  cache.insert("key6", geojson);
-  cache.delete("key6");
-  const catalogEntry = cache.catalogRetrieve("key6");
+  cache.insert('key6', geojson);
+  cache.delete('key6');
+  const catalogEntry = cache.catalogRetrieve('key6');
   t.deepEquals(_.omit(catalogEntry, '_cache'), {
-    type: "FeatureCollection",
-    crs: { type: "name", properties: { type: "EPSG:4326" } },
-    metadata: { name: "Test", description: "Test" }
+    type: 'FeatureCollection',
+    crs: { type: 'name', properties: { type: 'EPSG:4326' } },
+    metadata: { name: 'Test', description: 'Test' },
   });
 });
 
-test("Delete the catalog entry after its data has been deleted", (t) => {
+test('Delete the catalog entry after its data has been deleted', (t) => {
   const geojson = getFeatures();
   t.plan(2);
-  cache.insert("key6", geojson);
-  cache.delete("key6");
-  cache.catalogDelete("key6");
-  cache.catalogRetrieve("key6", (err) => {
-    t.ok(err, "Should return an error");
+  cache.insert('key6', geojson);
+  cache.delete('key6');
+  cache.catalogDelete('key6');
+  cache.catalogRetrieve('key6', (err) => {
+    t.ok(err, 'Should return an error');
     t.equal(
       err.message,
-      "Resource not found",
-      "Error should have correct message"
+      'Resource not found',
+      'Error should have correct message'
     );
   });
 });
 
-test("Helper prepares geojson for cache", (t) => {
+test('Helper prepares geojson for cache', (t) => {
   const full = getFeatures();
   const features = full.features;
   const empty = {};
@@ -214,50 +214,50 @@ test("Helper prepares geojson for cache", (t) => {
   const undefinedAsGeojson = asCachableGeojson(undefined);
   t.equal(
     fullGeojson.features[0].properties.key,
-    "value",
-    "Full geojson stays geojson"
+    'value',
+    'Full geojson stays geojson'
   );
   t.equal(
     featuresAsGeojson.features[0].properties.key,
-    "value",
-    "Features is converted to geojson"
+    'value',
+    'Features is converted to geojson'
   );
-  t.equal(emptyAsGeojson.features.length, 0, "Empty object becomes geojson");
-  t.equal(nullAsGeojson.features.length, 0, "Null object becomes geojson");
+  t.equal(emptyAsGeojson.features.length, 0, 'Empty object becomes geojson');
+  t.equal(nullAsGeojson.features.length, 0, 'Null object becomes geojson');
   t.equal(
     undefinedAsGeojson.features.length,
     0,
-    "Undefined object becomes geojson"
+    'Undefined object becomes geojson'
   );
   t.end();
 });
 
-test("Post-insert edits to geojson should not mutate cache", (t) => {
+test('Post-insert edits to geojson should not mutate cache', (t) => {
   const geojson = getFeatures();
-  cache.insert("key", geojson, { ttl: 600 });
-  geojson.features[0].properties.key = "fooz";
-  const cached = cache.retrieve("key");
-  t.equal(cached.features[0].properties.key, "value", "retrieved features");
-  t.equal(cached.crs.type, "name", "retrieved coordinate reference system");
-  t.equal(cached.metadata.name, "Test", "retrieved metadata");
-  t.ok(cached._cache.expires, "expiration set");
-  t.ok(cached._cache.updated, "updated set");
+  cache.insert('key', geojson, { ttl: 600 });
+  geojson.features[0].properties.key = 'fooz';
+  const cached = cache.retrieve('key');
+  t.equal(cached.features[0].properties.key, 'value', 'retrieved features');
+  t.equal(cached.crs.type, 'name', 'retrieved coordinate reference system');
+  t.equal(cached.metadata.name, 'Test', 'retrieved metadata');
+  t.ok(cached._cache.expires, 'expiration set');
+  t.ok(cached._cache.updated, 'updated set');
   t.end();
 });
 
-test("Post-update edits to geojson should not mutate cache", (t) => {
+test('Post-update edits to geojson should not mutate cache', (t) => {
   const geojson = getFeatures();
   const geojson2 = _.cloneDeep(geojson);
-  geojson2.features[0].properties.key = "test2";
+  geojson2.features[0].properties.key = 'test2';
 
-  cache.insert("key3", geojson, { ttl: 600 });
-  cache.update("key3", geojson2, { ttl: 1000 });
-  geojson.features[0].properties.key = "fooz";
-  const cached = cache.retrieve("key3");
+  cache.insert('key3', geojson, { ttl: 600 });
+  cache.update('key3', geojson2, { ttl: 1000 });
+  geojson.features[0].properties.key = 'fooz';
+  const cached = cache.retrieve('key3');
   t.equal(
     cached.features[0].properties.key,
-    "test2",
-    "retrieved unmutated feature"
+    'test2',
+    'retrieved unmutated feature'
   );
   t.end();
 });


### PR DESCRIPTION
Data stored in the cache has been mutable.  If you send GeoJSON to the memory cache, it gets stored, but it appears that some post-caching, koop-triggered transformations have the ability to mutate the GeoJSON _while it is in the cache_.  This mutating breaks some functionality, because the cached feature data is suppose to be immutable.

This PR:
- Makes cached data immutable from outside the cache-plugin by deep cloning data prior to caching
- Refactors the cache class so that it no longer uses deprecated `Util.inherits`
- Moves catalog methods outside of prototype `catalog` namespace; this avoids context confusion with `this`. (Technically this is a breaking change, but note that Koop-core does not directly use these changed catalog methods

